### PR TITLE
task: マージ済みのブランチを削除するタスクを作成

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,4 @@
+version: 3
+
+includes:
+  git: ./taskfiles/git.yaml

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -20,6 +20,7 @@
 		"samber",
 		"sqlboiler",
 		"sslmode",
+		"taskfiles",
 		"tbls",
 		"testdata",
 		"tmpl",

--- a/taskfiles/git.yaml
+++ b/taskfiles/git.yaml
@@ -1,0 +1,26 @@
+version: 3
+
+tasks:
+  prune_branch:
+    desc: マージ済みのブランチを削除
+    cmds:
+      - git fetch --prune
+      - task: checkout_default_branch
+      - git branch | grep -v {{.DEFAULT_BRANCH}} | xargs git branch -D
+    vars:
+      DEFAULT_BRANCH:
+        sh: git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+      CURRENT_BRANCH:
+        sh: git branch --show-current
+    status:
+      - test $(git branch | wc -l) -eq 1
+
+  checkout_default_branch:
+    cmds:
+      - git checkout {{.DEFAULT_BRANCH}}
+    vars:
+      DEFAULT_BRANCH:
+        sh: git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+    status:
+      - git branch --show-current | grep {{.DEFAULT_BRANCH}}
+    internal: true

--- a/taskfiles/git.yaml
+++ b/taskfiles/git.yaml
@@ -2,25 +2,25 @@ version: 3
 
 tasks:
   prune_branch:
-    desc: マージ済みのブランチを削除
+    desc: ローカルのブランチをリモートのブランチと比較して削除します
     cmds:
       - git fetch --prune
       - task: checkout_default_branch
       - git branch | grep -v {{.DEFAULT_BRANCH}} | xargs git branch -D
+    status:
+      - test $(git branch | wc -l) -eq 1
     vars:
       DEFAULT_BRANCH:
         sh: git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
       CURRENT_BRANCH:
         sh: git branch --show-current
-    status:
-      - test $(git branch | wc -l) -eq 1
 
   checkout_default_branch:
     cmds:
       - git checkout {{.DEFAULT_BRANCH}}
+    status:
+      - git branch --show-current | grep {{.DEFAULT_BRANCH}}
     vars:
       DEFAULT_BRANCH:
         sh: git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
-    status:
-      - git branch --show-current | grep {{.DEFAULT_BRANCH}}
     internal: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- Git関連のタスクを管理するための新しい設定ファイル`taskfiles/git.yaml`を追加しました。
	- マージされたブランチをクリーンアップする`prune_branch`タスクと、デフォルトブランチに切り替える`checkout_default_branch`タスクを導入しました。
  
- **改善**
	- プロジェクトのタスク管理を強化するために`Taskfile.yaml`にバージョン管理を導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->