### PR TITLE
fix: apply checkを分離

### DIFF
--- a/.github/workflows/atlas-apply.yaml
+++ b/.github/workflows/atlas-apply.yaml
@@ -29,11 +29,6 @@ jobs:
         run: |
           curl -sSf https://atlasgo.sh | sh -s -- -y
       - uses: actions/setup-go@v5
-      - name: Install tools
-        run: |
-          go install -v github.com/k1LoW/tbls@latest
-          go install -v github.com/volatiletech/sqlboiler/v4@latest
-          go install -v github.com/volatiletech/sqlboiler/v4/drivers/sqlboiler-psql@latest
       - name: task apply
         id: apply
         run: |
@@ -47,6 +42,14 @@ jobs:
           export POSTGRES_DB
           export POSTGRES_HOST
           export POSTGRES_PORT
-          task apply
-      - name: check-diff
-        run: git add . && git diff --cached
+          task apply_ci
+      - name: tbls
+        run: |
+          task tbls
+          git add .
+          git diff --cached --exit-code
+      - name: sqlboiler
+        run: |
+          task sqlboiler
+          git add .
+          git diff --cached --exit-code

--- a/api/Taskfile.yaml
+++ b/api/Taskfile.yaml
@@ -31,6 +31,10 @@ tasks:
       - task: tbls
       - task: sqlboiler
 
+  apply_ci:
+    cmds:
+      - atlas schema apply -u $POSTGRES_URL --to $SCHEMA_FILES --auto-approve
+
   sqlboiler:
     cmd: sqlboiler psql
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - CIプロセスの一環として、PostgreSQLデータベースにスキーマを適用する新しいタスク「apply_ci」を追加しました。
  
- **改善**
  - GitHub Actionsのワークフローを簡素化し、特定のツールのインストールを削除し、タスクの実行を明確に分離しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->