### PR TITLE
feat: upgrade memory of web container

### DIFF
--- a/infra/terraform/remote/croud_run.tf
+++ b/infra/terraform/remote/croud_run.tf
@@ -111,7 +111,7 @@ resource "google_cloud_run_v2_service" "web" {
         cpu_idle = true
         limits = {
           cpu    = "2"
-          memory = "1024Mi"
+          memory = "2Gi"
         }
       }
       ports {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Webサービスのメモリ制限を1024Miから2Giに増加しました。これにより、パフォーマンスが向上し、より多くのリソースを必要とする処理が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->