### PR TITLE
chore: reduce limit instance

### DIFF
--- a/infra/terraform/remote/croud_run.tf
+++ b/infra/terraform/remote/croud_run.tf
@@ -6,7 +6,7 @@ resource "google_cloud_run_v2_service" "api" {
   template {
     service_account = google_service_account.cloud_run_service_account.email
     scaling {
-      max_instance_count = 3
+      max_instance_count = 1
       min_instance_count = 0
     }
     containers {
@@ -102,7 +102,7 @@ resource "google_cloud_run_v2_service" "web" {
   template {
     service_account = google_service_account.cloud_run_service_account.email
     scaling {
-      max_instance_count = 3
+      max_instance_count = 1
       min_instance_count = 0
     }
     containers {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- Google Cloud Run サービスのスケーリング設定を更新し、最大インスタンス数を 3 から 1 に減少しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->