### PR TITLE
Reduce-cost

### DIFF
--- a/infra/terraform/remote/.terraform.lock.hcl
+++ b/infra/terraform/remote/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "5.37.0"
-  constraints = "5.37.0"
+  constraints = ">= 4.40.0, 5.37.0, < 6.0.0"
   hashes = [
     "h1:ECJCeUsjARe6GHI1yLQKdsx1GW1CFqgww/dzooBe/xk=",
     "zh:00754c426ec8c2416d54904b25ebf3d831b5af4f02a20336d0a60d91897497d7",
@@ -23,7 +23,7 @@ provider "registry.terraform.io/hashicorp/google" {
 
 provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "5.42.0"
-  constraints = ">= 4.50.0, < 6.0.0"
+  constraints = ">= 4.40.0, ~> 5.42.0, < 6.0.0"
   hashes = [
     "h1:H+tooloi4YDGWfcDUG7cJddHCT7lRpiWIAP02hpEVno=",
     "zh:0105d0f1564f31e7c68260f68fba12a1ed5d3bf5dfb04dd19492b3dd464991e5",
@@ -42,21 +42,21 @@ provider "registry.terraform.io/hashicorp/google-beta" {
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.6.2"
+  version     = "3.6.3"
   constraints = ">= 2.1.0"
   hashes = [
-    "h1:UQlmHGddu39vVzG8kruMsde4GHlG+1S7OLqFApbJvtc=",
-    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
-    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
-    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
-    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
-    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
-    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
-    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "h1:In4XBRMdhY89yUoTUyar3wDF28RJlDpQzdjahp59FAk=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
-    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
-    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
-    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
   ]
 }

--- a/infra/terraform/remote/croud_run.tf
+++ b/infra/terraform/remote/croud_run.tf
@@ -97,7 +97,7 @@ resource "google_cloud_run_v2_service" "api" {
 resource "google_cloud_run_v2_service" "web" {
   name     = "web"
   location = local.region
-  ingress  = "INGRESS_TRAFFIC_ALL"
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
   template {
     service_account = google_service_account.cloud_run_service_account.email

--- a/infra/terraform/remote/dns.tf
+++ b/infra/terraform/remote/dns.tf
@@ -1,24 +1,24 @@
-module "cloud-dns" {
-  source  = "terraform-google-modules/cloud-dns/google"
-  version = "5.2.0"
+# module "cloud-dns" {
+#   source  = "terraform-google-modules/cloud-dns/google"
+#   version = "5.2.0"
 
-  project_id = local.project_id
-  name       = "share-cart-com"
-  domain     = "share-cart.com."
-  type       = "public"
+#   project_id = local.project_id
+#   name       = "share-cart-com"
+#   domain     = "share-cart.com."
+#   type       = "public"
 
-  dnssec_config = {
-    state = "on"
-  }
+#   dnssec_config = {
+#     state = "on"
+#   }
 
-  recordsets = [
-    {
-      name = ""
-      type = "A"
-      ttl  = 300
-      records = [
-        module.lb-http.external_ip,
-      ]
-    },
-  ]
-}
+#   recordsets = [
+#     {
+#       name = ""
+#       type = "A"
+#       ttl  = 300
+#       records = [
+#         module.lb-http.external_ip,
+#       ]
+#     },
+#   ]
+# }

--- a/infra/terraform/remote/load_balancer.tf
+++ b/infra/terraform/remote/load_balancer.tf
@@ -1,42 +1,42 @@
-# module "lb-http" {
-#   source  = "terraform-google-modules/lb-http/google//modules/serverless_negs"
-#   version = "~> 10.0"
+module "lb-http" {
+  source  = "terraform-google-modules/lb-http/google//modules/serverless_negs"
+  version = "~> 10.0"
 
-#   name    = "web-lb"
-#   project = local.project_id
+  name    = "web-lb"
+  project = local.project_id
 
-#   ssl                             = true
-#   https_redirect                  = true
-#   managed_ssl_certificate_domains = [local.web_domain]
-#   labels                          = { "service" = "share-cart" }
+  ssl                             = true
+  https_redirect                  = true
+  managed_ssl_certificate_domains = [local.web_domain]
+  labels                          = { "service" = "share-cart" }
 
-#   backends = {
-#     default = {
-#       description = "share cart web load balancer"
-#       groups = [
-#         {
-#           group = google_compute_region_network_endpoint_group.web_neg.id
-#         }
-#       ]
-#       enable_cdn = false
+  backends = {
+    default = {
+      description = "share cart web load balancer"
+      groups = [
+        {
+          group = google_compute_region_network_endpoint_group.web_neg.id
+        }
+      ]
+      enable_cdn = false
 
-#       iap_config = {
-#         enable = false
-#       }
-#       log_config = {
-#         enable = true
-#       }
-#     }
-#   }
-# }
+      iap_config = {
+        enable = false
+      }
+      log_config = {
+        enable = true
+      }
+    }
+  }
+}
 
 
-# resource "google_compute_region_network_endpoint_group" "web_neg" {
-#   provider              = google-beta
-#   name                  = "web-neg"
-#   network_endpoint_type = "SERVERLESS"
-#   region                = local.region
-#   cloud_run {
-#     service = google_cloud_run_v2_service.web.name
-#   }
-# }
+resource "google_compute_region_network_endpoint_group" "web_neg" {
+  provider              = google-beta
+  name                  = "web-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = local.region
+  cloud_run {
+    service = google_cloud_run_v2_service.web.name
+  }
+}

--- a/infra/terraform/remote/load_balancer.tf
+++ b/infra/terraform/remote/load_balancer.tf
@@ -1,42 +1,42 @@
-module "lb-http" {
-  source  = "terraform-google-modules/lb-http/google//modules/serverless_negs"
-  version = "~> 10.0"
+# module "lb-http" {
+#   source  = "terraform-google-modules/lb-http/google//modules/serverless_negs"
+#   version = "~> 10.0"
 
-  name    = "web-lb"
-  project = local.project_id
+#   name    = "web-lb"
+#   project = local.project_id
 
-  ssl                             = true
-  https_redirect                  = true
-  managed_ssl_certificate_domains = [local.web_domain]
-  labels                          = { "service" = "share-cart" }
+#   ssl                             = true
+#   https_redirect                  = true
+#   managed_ssl_certificate_domains = [local.web_domain]
+#   labels                          = { "service" = "share-cart" }
 
-  backends = {
-    default = {
-      description = "share cart web load balancer"
-      groups = [
-        {
-          group = google_compute_region_network_endpoint_group.web_neg.id
-        }
-      ]
-      enable_cdn = false
+#   backends = {
+#     default = {
+#       description = "share cart web load balancer"
+#       groups = [
+#         {
+#           group = google_compute_region_network_endpoint_group.web_neg.id
+#         }
+#       ]
+#       enable_cdn = false
 
-      iap_config = {
-        enable = false
-      }
-      log_config = {
-        enable = true
-      }
-    }
-  }
-}
+#       iap_config = {
+#         enable = false
+#       }
+#       log_config = {
+#         enable = true
+#       }
+#     }
+#   }
+# }
 
 
-resource "google_compute_region_network_endpoint_group" "web_neg" {
-  provider              = google-beta
-  name                  = "web-neg"
-  network_endpoint_type = "SERVERLESS"
-  region                = local.region
-  cloud_run {
-    service = google_cloud_run_v2_service.web.name
-  }
-}
+# resource "google_compute_region_network_endpoint_group" "web_neg" {
+#   provider              = google-beta
+#   name                  = "web-neg"
+#   network_endpoint_type = "SERVERLESS"
+#   region                = local.region
+#   cloud_run {
+#     service = google_cloud_run_v2_service.web.name
+#   }
+# }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **インフラストラクチャの変更**
	- Cloud Runサービスのトラフィックルーティングを内部ロードバランサーに制限
	- Webサービスのメモリ制限を512MiBから2Giに増加
	- コンテナのリスニングポートを8080から3000に変更
	- APIサービスへの新しい環境変数を追加

- **DNSの変更**
	- Cloud DNSモジュールを一時的に無効化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->